### PR TITLE
Remove post request method checks in actions

### DIFF
--- a/client/app/routes/courses.tsx
+++ b/client/app/routes/courses.tsx
@@ -3,20 +3,13 @@ import { prisma } from "~/lib/prisma.server";
 import { slugify } from "~/lib/slugify";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
-	if (request.method !== "POST") {
-		return new Response(null, {
-			status: 405,
-			statusText: "Method Not Allowed",
-		});
-	}
+  const data = await request.json();
 
-	const data = await request.json();
+  const { code, name } = data;
 
-	const { code, name } = data;
+  await prisma.course.create({
+    data: { code, name, slug: slugify(`${code} ${name}`) },
+  });
 
-	await prisma.course.create({
-		data: { code, name, slug: slugify(`${code} ${name}`) },
-	});
-
-	return json({});
+  return json({});
 };

--- a/client/app/routes/instructors.tsx
+++ b/client/app/routes/instructors.tsx
@@ -2,16 +2,9 @@ import { ActionFunctionArgs, json } from "@remix-run/node";
 import { prisma } from "~/lib/prisma.server";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
-	if (request.method !== "POST") {
-		return new Response(null, {
-			status: 405,
-			statusText: "Method Not Allowed",
-		});
-	}
+  const data = await request.json();
 
-	const data = await request.json();
+  await prisma.instructor.create({ data });
 
-	await prisma.instructor.create({ data });
-
-	return json({});
+  return json({});
 };

--- a/client/app/routes/programmes.tsx
+++ b/client/app/routes/programmes.tsx
@@ -3,19 +3,15 @@ import { prisma } from "~/lib/prisma.server";
 import { slugify } from "~/lib/slugify";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
-	if (request.method !== "POST") {
-		throw new Response(null, { status: 405 });
-	}
+  const data = await request.json();
+  const programmeData = {
+    name: data.name,
+    slug: slugify(data.name),
+  };
 
-	const data = await request.json();
-	const programmeData = {
-		name: data.name,
-		slug: slugify(data.name),
-	};
+  const programme = await prisma.programme.create({
+    data: programmeData,
+  });
 
-	const programme = await prisma.programme.create({
-		data: programmeData,
-	});
-
-	return json({ programme });
+  return json({ programme });
 };


### PR DESCRIPTION
Checking request methods in the actions are redundant since actions are only called for post requests. 